### PR TITLE
Add removable & resizable frames, faster rain

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,6 +2,4 @@
 
 This small project renders a Matrix style "digital rain" animation on an HTML canvas.
 
-To see it in action, simply open `index.html` in your browser. The rain has been
-slowed down for a more relaxed look and uses both Latin and Katakana symbols for
-a more authentic vibe.
+To see it in action, simply open `index.html` in your browser. The rain is slightly faster now and uses both Latin and Katakana symbols for a more authentic vibe. Each added frame can be resized and removed with the red **X** in its corner.

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ let columns;
 let drops;
 
 // How often the matrix updates. Higher values slow down the animation.
-const speed = 150; // milliseconds
+const speed = 80; // milliseconds - a bit faster
 // Initialize drops based on current window size and update on resize
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
@@ -76,9 +76,15 @@ function makeDraggable(el) {
 addButton.addEventListener('click', () => {
     const frame = document.createElement('div');
     frame.className = 'frame';
-    frame.textContent = 'Frame ' + (++frameCount);
+    frame.innerHTML = `<span class="close">\u2716</span>Frame ${++frameCount}`;
     frame.style.left = '50px';
     frame.style.top = '50px';
     container.appendChild(frame);
     makeDraggable(frame);
+
+    const close = frame.querySelector('.close');
+    close.addEventListener('click', e => {
+        e.stopPropagation();
+        frame.remove();
+    });
 });

--- a/style.css
+++ b/style.css
@@ -38,4 +38,15 @@ body, html {
     padding: 10px;
     box-sizing: border-box;
     cursor: move;
+    resize: both;
+    overflow: auto;
+}
+
+.frame .close {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    color: red;
+    font-weight: bold;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- speed up rain animation a bit
- make frames resizable and add red close button
- update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fa18a6e08322b30b814b1fa8e428