### PR TITLE
Add frame removal and better resizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,9 +52,11 @@ setInterval(drawMatrix, speed);
 const addButton = document.getElementById('addFrame');
 const container = document.getElementById('framesContainer');
 let frameCount = 0;
+let zIndexCounter = 1;
 
-function makeDraggable(el) {
+function makeDraggable(el, ignoreSelector) {
     let offsetX, offsetY;
+    const ignoreEl = ignoreSelector ? el.querySelector(ignoreSelector) : null;
     const onMouseMove = e => {
         el.style.left = e.pageX - offsetX + 'px';
         el.style.top = e.pageY - offsetY + 'px';
@@ -66,8 +68,12 @@ function makeDraggable(el) {
     };
 
     el.addEventListener('mousedown', e => {
+        if (ignoreEl && (e.target === ignoreEl || ignoreEl.contains(e.target))) {
+            return;
+        }
         offsetX = e.offsetX;
         offsetY = e.offsetY;
+        el.style.zIndex = ++zIndexCounter;
         document.addEventListener('mousemove', onMouseMove);
         document.addEventListener('mouseup', onMouseUp);
     });
@@ -80,9 +86,10 @@ addButton.addEventListener('click', () => {
     frame.style.left = '50px';
     frame.style.top = '50px';
     container.appendChild(frame);
-    makeDraggable(frame);
+    makeDraggable(frame, '.close');
 
     const close = frame.querySelector('.close');
+    close.addEventListener('mousedown', e => e.stopPropagation());
     close.addEventListener('click', e => {
         e.stopPropagation();
         frame.remove();

--- a/style.css
+++ b/style.css
@@ -40,6 +40,7 @@ body, html {
     cursor: move;
     resize: both;
     overflow: auto;
+    z-index: 10;
 }
 
 .frame .close {
@@ -49,4 +50,5 @@ body, html {
     color: red;
     font-weight: bold;
     cursor: pointer;
+    user-select: none;
 }


### PR DESCRIPTION
## Summary
- ensure frames appear above the matrix and the close button is not selectable
- improve drag helper to ignore the close button and manage z-index
- stop drag when clicking the close button and allow frame removal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fb35c2948322b9f910390f429ffe