### PR TITLE
Add header with datetime and weather

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <div id="header">
+        <div id="datetime"></div>
+        <h1 id="title">Route Operations Dashboard</h1>
+        <div id="weather">Loading weather...</div>
+    </div>
     <canvas id="matrix"></canvas>
     <button id="addFrame">Add Frame</button>
     <div id="framesContainer"></div>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,7 @@
+// Header elements
+const datetimeEl = document.getElementById('datetime');
+const weatherEl = document.getElementById('weather');
+
 // Matrix rain effect
 const canvas = document.getElementById('matrix');
 const ctx = canvas.getContext('2d');
@@ -22,6 +26,40 @@ const speed = 80; // milliseconds - a bit faster
 // Initialize drops based on current window size and update on resize
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
+
+function updateDateTime() {
+    const now = new Date();
+    const options = {
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: true,
+    };
+    const date = now.toLocaleDateString('en-US');
+    const time = now.toLocaleTimeString('en-US', options);
+    datetimeEl.textContent = `${date} ${time}`;
+}
+setInterval(updateDateTime, 1000);
+updateDateTime();
+
+function loadWeather() {
+    const url =
+        'https://api.open-meteo.com/v1/forecast?latitude=39.9578&longitude=-82.8993&current_weather=true&temperature_unit=fahrenheit';
+    fetch(url)
+        .then(r => r.json())
+        .then(data => {
+            if (data && data.current_weather) {
+                const t = Math.round(data.current_weather.temperature);
+                weatherEl.textContent = `${t}\u00B0F`;
+            } else {
+                weatherEl.textContent = 'N/A';
+            }
+        })
+        .catch(() => {
+            weatherEl.textContent = 'N/A';
+        });
+}
+loadWeather();
 
 function drawMatrix() {
     // Slightly darken the entire canvas to create the trail effect

--- a/style.css
+++ b/style.css
@@ -7,6 +7,34 @@ body, html {
     font-family: sans-serif;
 }
 
+#header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.8);
+    color: #0f0;
+    z-index: 1000;
+}
+
+#title {
+    flex: 1;
+    text-align: center;
+    font-size: 2em;
+}
+
+#datetime,
+#weather {
+    width: 25%;
+    text-align: center;
+    font-size: 1em;
+}
+
 #matrix {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- add header with big title and placeholders for date/time and weather
- style header elements
- show current time in 12-hour format and fetch temperature in Fahrenheit using Open-Meteo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ff2d8028832286865e4e22d9d49c