### PR TITLE
Style header content above matrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
 </head>
 <body>
     <div id="header">
-        <div id="datetime"></div>
-        <h1 id="title">Route Operations Dashboard</h1>
-        <div id="weather">Loading weather...</div>
+        <div id="datetime" class="info-block"></div>
+        <h1 id="title" class="info-block">Route Operations Dashboard</h1>
+        <div id="weather" class="info-block">Loading weather...</div>
     </div>
     <canvas id="matrix"></canvas>
     <button id="addFrame">Add Frame</button>

--- a/style.css
+++ b/style.css
@@ -17,9 +17,18 @@ body, html {
     align-items: center;
     padding: 10px;
     box-sizing: border-box;
-    background: rgba(0, 0, 0, 0.8);
-    color: #0f0;
+    background: rgba(0, 16, 0, 0.9);
+    color: #fff;
+    border: 2px solid #0f0;
     z-index: 1000;
+}
+
+.info-block {
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid #0f0;
+    padding: 5px;
+    color: #fff;
+    border-radius: 4px;
 }
 
 #title {


### PR DESCRIPTION
## Summary
- add `info-block` styling for header components and apply it in index
- use a dark green header background with a bright green border
- ensure header text remains readable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843005689b08322b0cc32ab979cf9e3