### PR TITLE
Fix datetime border width

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,17 +37,19 @@ body, html {
     font-size: 2em;
 }
 
-#datetime,
 #weather-container {
     width: 25%;
     text-align: center;
     font-size: 1em;
-}
-
-#weather-container {
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+#datetime {
+    width: auto;
+    text-align: center;
+    font-size: 1em;
 }
 
 #matrix {


### PR DESCRIPTION
## Summary
- allow datetime info-block to shrink to content

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684304fbe6f483229e22e69d4c38b9e4