### PR TITLE
Remove inner borders from header blocks

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,7 +25,6 @@ body, html {
 
 .info-block {
     background: rgba(0, 0, 0, 0.6);
-    border: 1px solid #0f0;
     padding: 5px;
     color: #fff;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- only show the outer green border around the header
- remove the thin borders from individual header items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843067de0d8832284d01eee3d76cac1