### PR TITLE
Allow editable frame titles and persist layout on server

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,4 +2,13 @@
 
 This small project renders a Matrix style "digital rain" animation on an HTML canvas.
 
-To see it in action, simply open `index.html` in your browser. The rain is slightly faster now and uses both Latin and Katakana symbols for a more authentic vibe. Each added frame can be moved, resized, minimized with the green underscore, and removed with the red **X** in its corner. Frame positions, sizes and minimized state are saved locally so they persist when you reload the page.
+The page also includes movable frames. You can change a frame's title by clicking on it. Layout and titles are saved to `frames.json` on the server and restored when the page loads.
+
+To run the site with persistence enabled, install dependencies and start the server:
+
+```
+npm install
+npm start
+```
+
+Open `http://localhost:3000` in your browser to see the matrix rain animation. Frames can be moved, resized, minimized with the green underscore, and removed with the red **X** in their corner. Layout is saved server side so it persists across browsers.

--- a/frames.json
+++ b/frames.json
@@ -1,0 +1,1 @@
+{"frameCount":0,"frames":[]}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "matrixrain",
+  "version": "1.0.0",
+  "description": "Matrix rain with editable frames",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const port = 3000;
+const saveFile = path.join(__dirname, 'frames.json');
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+app.get('/frames', (req, res) => {
+  fs.readFile(saveFile, 'utf8', (err, data) => {
+    if (err) {
+      return res.json({ frameCount: 0, frames: [] });
+    }
+    try {
+      res.json(JSON.parse(data));
+    } catch {
+      res.json({ frameCount: 0, frames: [] });
+    }
+  });
+});
+
+app.post('/frames', (req, res) => {
+  fs.writeFile(saveFile, JSON.stringify(req.body || {}), err => {
+    if (err) {
+      console.error('Failed to save frames', err);
+      return res.status(500).json({ message: 'Failed to save' });
+    }
+    res.json({ status: 'ok' });
+  });
+});
+
+app.listen(port, () => console.log(`Server listening on port ${port}`));

--- a/style.css
+++ b/style.css
@@ -123,6 +123,19 @@ body, html {
     font-size: 18px;
 }
 
+.frame .title {
+    display: block;
+    font-weight: bold;
+    margin-top: 18px;
+    margin-bottom: 4px;
+    cursor: text;
+    user-select: text;
+}
+
+.frame.minimized .title {
+    margin-top: 0;
+}
+
 .frame.minimized {
     height: 26px;          /* keep controls visible when minimized */
     padding: 2px 10px;     /* reduce padding so buttons aren't clipped */


### PR DESCRIPTION
## Summary
- let frames be renamed via an editable title
- persist layout and titles to `frames.json` on the server
- provide a small Express server for saving/loading frame state
- document running the server in README

## Testing
- `npm install --silent` *(fails: no output)*
- `npm test` *(fails: Missing script: "test")*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68430e1363448322946616363120d142