### PR TITLE
Improve frame layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -145,8 +145,19 @@ function createFrame(info) {
     const frame = document.createElement('div');
     frame.className = 'frame';
     frame.dataset.id = info.id;
-    frame.innerHTML =
-        `<span class="close">\u2716</span><span class="minimize">&#95;</span><div class="title" contenteditable="true">${info.title || ''}</div><div class="content">${info.content}</div>`;
+
+    const header = document.createElement('div');
+    header.className = 'frame-header';
+    header.innerHTML =
+        `<span class="close">\u2716</span><span class="minimize">&#95;</span><div class="title" contenteditable="true">${info.title || ''}</div>`;
+    frame.appendChild(header);
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    content.contentEditable = 'true';
+    content.innerHTML = info.content;
+    frame.appendChild(content);
+
     frame.style.left = (info.left || 0) + 'px';
     frame.style.top = (info.top || 0) + 'px';
     frame.style.width = (info.width || 200) + 'px';
@@ -154,7 +165,7 @@ function createFrame(info) {
     if (info.minimized) frame.classList.add('minimized');
     container.appendChild(frame);
     constrainFrame(frame);
-    makeDraggable(frame, '.close, .minimize, .resizer, .title');
+    makeDraggable(header, '.close, .minimize, .title');
     makeResizable(frame);
 
     const close = frame.querySelector('.close');
@@ -168,6 +179,10 @@ function createFrame(info) {
     const title = frame.querySelector('.title');
     title.addEventListener('mousedown', e => e.stopPropagation());
     title.addEventListener('blur', saveFrames);
+
+    const body = frame.querySelector('.content');
+    body.addEventListener('mousedown', e => e.stopPropagation());
+    body.addEventListener('blur', saveFrames);
 
     const minimize = frame.querySelector('.minimize');
     minimize.addEventListener('mousedown', e => e.stopPropagation());

--- a/style.css
+++ b/style.css
@@ -92,11 +92,33 @@ body, html {
     background: rgba(0, 0, 0, 0.7);
     border: 1px solid #0f0;
     color: #0f0;
-    padding: 10px;
+    padding: 0;
     box-sizing: border-box;
-    cursor: move;
-    overflow: auto;
+    overflow: hidden;
     z-index: 10;
+}
+
+.frame-header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.8);
+    padding: 2px 10px;
+    border-bottom: 1px solid #0f0;
+    cursor: move;
+}
+
+.frame-header .title {
+    flex: 1;
+    font-weight: bold;
+    margin: 0;
+    cursor: text;
+    user-select: text;
+}
+
+.frame .content {
+    padding: 10px;
+    overflow: auto;
 }
 
 .frame .close {
@@ -123,22 +145,8 @@ body, html {
     font-size: 18px;
 }
 
-.frame .title {
-    display: block;
-    font-weight: bold;
-    margin-top: 18px;
-    margin-bottom: 4px;
-    cursor: text;
-    user-select: text;
-}
-
-.frame.minimized .title {
-    margin-top: 0;
-}
-
 .frame.minimized {
-    height: 26px;          /* keep controls visible when minimized */
-    padding: 2px 10px;     /* reduce padding so buttons aren't clipped */
+    height: 28px;          /* keep controls visible when minimized */
     overflow: hidden;      /* hide any scrollbars */
 }
 


### PR DESCRIPTION
## Summary
- create explicit header and body sections for frames
- allow editing of frame body content
- drag frames by their header

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68431053fdc08322a54d88bbe58a8ef4