### PR TITLE
Update header cursor behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,6 +102,7 @@ body, html {
     position: relative;
     display: flex;
     align-items: center;
+    justify-content: center; /* leave space around the title for dragging */
     background: rgba(0, 0, 0, 0.8);
     padding: 2px 10px;
     border-bottom: 1px solid #0f0;
@@ -109,7 +110,7 @@ body, html {
 }
 
 .frame-header .title {
-    flex: 1;
+    flex: none; /* don't cover the entire header */
     font-weight: bold;
     margin: 0;
     cursor: text;
@@ -127,7 +128,7 @@ body, html {
     right: 4px;
     color: red;
     font-weight: bold;
-    cursor: pointer;
+    cursor: move; /* keep drag cursor for entire header */
     user-select: none;
 }
 
@@ -137,7 +138,7 @@ body, html {
     right: 20px;
     color: #0f0;
     font-weight: bold;
-    cursor: pointer;
+    cursor: move; /* keep drag cursor for entire header */
     user-select: none;
     background: #000;
     padding: 0 3px;


### PR DESCRIPTION
## Summary
- tweak header layout so the title doesn't cover the whole header
- show move cursor on header buttons to keep the cross-arrow everywhere but the title

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68431782c1fc83229bf7ebbf08f46af3