### PR TITLE
Remove focus outline on frame titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,6 +115,12 @@ body, html {
     margin: 0;
     cursor: text;
     user-select: text;
+    outline: none;
+}
+
+/* hide focus outline that appears when editing the title */
+.frame-header .title:focus {
+    outline: none;
 }
 
 .frame .content {


### PR DESCRIPTION
## Summary
- style `.frame-header .title` to hide browser-provided focus outlines

## Testing
- `npm start` *(fails: Cannot check due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68431839e29c83229cf1dd7f8ea50b13