### PR TITLE
Add confirm prompt before deleting frames

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,4 +11,4 @@ npm install
 npm start
 ```
 
-Open `http://localhost:3000` in your browser to see the matrix rain animation. Frames can be moved, resized, minimized with the green underscore, and removed with the red **X** in their corner. Layout is saved server side so it persists across browsers.
+Open `http://localhost:3000` in your browser to see the matrix rain animation. Frames can be moved, resized, minimized with the green underscore, and removed with the red **X** in their corner. When removing a frame you will be asked to confirm the deletion. Layout is saved server side so it persists across browsers.

--- a/script.js
+++ b/script.js
@@ -214,8 +214,10 @@ function createFrame(info) {
     const close = frame.querySelector('.close');
     close.addEventListener('click', e => {
         e.stopPropagation();
-        frame.remove();
-        saveFrames();
+        if (confirm('ARE YOU SURE YOU WANT TO DELETE THE FRAME?')) {
+            frame.remove();
+            saveFrames();
+        }
     });
 
     const title = frame.querySelector('.title');


### PR DESCRIPTION
## Summary
- show a confirmation dialog when closing a frame
- document new confirmation behavior in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68431b6071c88322acabfe9d3f30be03