### PR TITLE
Change default frame position to right side

### DIFF
--- a/script.js
+++ b/script.js
@@ -433,11 +433,12 @@ addButton.addEventListener('click', () => {
     } else {
         id = ++frameCount;
     }
+    const frameWidth = 200;
     const info = {
         id,
-        left: 50,
+        left: window.innerWidth - frameWidth - 50,
         top: headerHeight + 10,
-        width: 200,
+        width: frameWidth,
         height: 150,
         minimized: false,
         title: `New Frame ${id}`,


### PR DESCRIPTION
## Summary
- spawn new frames near the right edge instead of the left

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6843649c3a208322858e7eb3e031eaff