### PR TITLE
Improve logo flag clarity

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,14 +40,19 @@ function startLogoWave() {
         return;
     }
     const ctxL = logoCanvas.getContext('2d');
-    logoCanvas.width = logoImg.naturalWidth;
-    logoCanvas.height = logoImg.naturalHeight;
+    // render at 150px wide for a crisp display
+    const desiredWidth = 150;
+    const scale = desiredWidth / logoImg.naturalWidth;
+    logoCanvas.width = desiredWidth;
+    logoCanvas.height = logoImg.naturalHeight * scale;
+    logoCanvas.style.width = desiredWidth + 'px';
+    logoCanvas.style.height = logoCanvas.height + 'px';
     logoImg.style.display = 'none';
 
     let t = 0;
-    const slice = 2;
-    const waveLength = 40;
-    const amplitude = 5;
+    const slice = 1;           // use 1px slices for higher fidelity
+    const waveLength = 50;     // slightly longer waves
+    const amplitude = 4;       // gentler movement for clarity
 
     function draw() {
         ctxL.clearRect(0, 0, logoCanvas.width, logoCanvas.height);

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body, html {
 }
 
 #logo {
-    width: 120px;
+    width: 150px;
     height: auto;
     display: block;
 }


### PR DESCRIPTION
## Summary
- enlarge logo display size
- render the flag animation at a fixed width with finer slices

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6843683f53048322bdd7b1e857db2948