### PR TITLE
Fix logo visibility and improve minimized frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <div id="header">
-        <img src="LogoHQ.png" id="logoImg" alt="Dublin Cleaners logo" hidden>
+        <img src="LogoHQ.png" id="logoImg" alt="Dublin Cleaners logo">
         <canvas id="logo"></canvas>
         <div id="title-container">
             <h1 id="title" class="info-block">Route Operations Dashboard</h1>

--- a/script.js
+++ b/script.js
@@ -28,7 +28,7 @@ let drops;
 // How often the matrix updates. Higher values slow down the animation.
 const speed = 80; // milliseconds - a bit faster
 // extra pixels to keep frame headers clickable when minimized
-const minimizePadding = 6;
+const minimizePadding = 20;
 // Initialize drops based on current window size and update on resize
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);

--- a/style.css
+++ b/style.css
@@ -36,7 +36,9 @@ body, html {
 }
 
 #logoImg {
-    display: none;
+    width: 150px;
+    height: auto;
+    display: block;
 }
 
 #logo {
@@ -170,7 +172,7 @@ body, html {
 
 .frame.minimized {
     /* leave a bit more room for the header when minimized */
-    height: 32px;
+    height: 52px;
     overflow: hidden;      /* hide any scrollbars */
 }
 


### PR DESCRIPTION
## Summary
- show logo image before animation starts
- allow more space when frames are minimized

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843699ced74832285adba80e1c190d7