### PR TITLE
Fix minimize toggle and keep logo on top

### DIFF
--- a/script.js
+++ b/script.js
@@ -275,7 +275,8 @@ function createFrame(info) {
     }
 
     constrainFrame(frame);
-    makeDraggable(frame, header);
+    // Prevent dragging when clicking the close or minimize buttons
+    makeDraggable(frame, header, '.close, .minimize');
     makeResizable(frame);
 
     if (framesLocked) {

--- a/style.css
+++ b/style.css
@@ -45,6 +45,8 @@ body, html {
     width: 150px;
     height: auto;
     display: block;
+    position: relative;
+    z-index: 10002;
 }
 
 #title-container {


### PR DESCRIPTION
## Summary
- keep the waving logo canvas above all other elements
- prevent drag logic from resetting saved frame height when clicking minimize/close

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68436b94badc83229c8a42ee884f7551