### PR TITLE
Update header and frame styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
         </div>
         <div id="weather-container">
             <div id="weather" class="info-block">Loading weather...</div>
+            <button id="lockFrames">🔒</button>
             <button id="addFrame">Add Frame</button>
-            <button id="lockFrames">Lock Frames</button>
         </div>
     </div>
     <canvas id="matrix"></canvas>

--- a/script.js
+++ b/script.js
@@ -460,7 +460,7 @@ loadFrames();
 
 lockButton.addEventListener('click', () => {
     framesLocked = !framesLocked;
-    lockButton.textContent = framesLocked ? 'Unlock Frames' : 'Lock Frames';
+    lockButton.textContent = framesLocked ? '🔓' : '🔒';
     container.querySelectorAll('.frame').forEach(f => {
         if (framesLocked) {
             f.classList.add('locked');

--- a/style.css
+++ b/style.css
@@ -32,7 +32,8 @@ body, html {
 
 #title {
     text-align: center;
-    font-size: 2em;
+    font-size: 4em; /* doubled size */
+    margin-bottom: 2px; /* reduce gap below title */
 }
 
 #logoImg {
@@ -66,6 +67,7 @@ body, html {
     width: auto;
     text-align: center;
     font-size: 1em;
+    margin-top: 2px; /* closer to title */
 }
 
 #matrix {
@@ -91,12 +93,17 @@ body, html {
 #lockFrames {
     margin-top: 5px;
     z-index: 10001;
-    padding: 8px 12px;
+    width: 50px;
+    height: 50px;
+    font-size: 40px;
+    line-height: 45px;
+    text-align: center;
     background: #222;
     color: #0f0;
     border: 1px solid #0f0;
     cursor: pointer;
-    margin-left: 5px;
+    margin-right: 5px; /* sits left of Add Frame */
+    padding: 0;
 }
 
 .frame {
@@ -106,6 +113,7 @@ body, html {
     background: rgba(0, 0, 0, 0.7);
     border: 1px solid #0f0;
     color: #0f0;
+    font-size: 2em; /* doubled text size */
     padding: 0;
     box-sizing: border-box;
     overflow: hidden;
@@ -217,7 +225,7 @@ body, html {
     color: #0f0;
     border: 1px solid #0f0;
     cursor: pointer;
-    font-size: 0.8em;
+    font-size: 1.6em; /* doubled size */
 }
 
 .frame.locked .resizer {


### PR DESCRIPTION
## Summary
- resize page header and reduce spacing to date/time
- enlarge text for frames and spreadsheet controls
- replace lock button text with padlock icon and reposition
- set lock toggle to use padlock emoji

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68437065968c83228b6b32f3cafc2dab