### PR TITLE
Fix quote of week fallback

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,6 +3,12 @@ const datetimeEl = document.getElementById('datetime');
 const weatherEl = document.getElementById('weather');
 const quoteEl = document.getElementById('weeklyQuote');
 
+const fallbackQuotes = [
+    'The best way to get started is to quit talking and begin doing. — Walt Disney',
+    'The pessimist sees difficulty in every opportunity. The optimist sees opportunity in every difficulty. — Winston Churchill',
+    'Don\'t let yesterday take up too much of today. — Will Rogers'
+];
+
 
 // Matrix rain effect
 const canvas = document.getElementById('matrix');
@@ -78,7 +84,7 @@ function shouldFetchQuote(lastTime) {
     const diffToMonday = (day + 6) % 7;
     const monday = new Date(est);
     monday.setDate(est.getDate() - diffToMonday);
-    monday.setHours(5, 0, 0, 0);
+    monday.setHours(17, 0, 0, 0);
     if (est < monday) {
         monday.setDate(monday.getDate() - 7);
     }
@@ -101,7 +107,10 @@ function loadWeeklyQuote() {
                 if (saved) {
                     quoteEl.textContent = saved;
                 } else {
-                    quoteEl.textContent = 'Quote unavailable';
+                    const fallback = fallbackQuotes[Math.floor(Math.random() * fallbackQuotes.length)];
+                    quoteEl.textContent = fallback;
+                    localStorage.setItem('weeklyQuote', fallback);
+                    localStorage.setItem('weeklyQuoteTime', Date.now());
                 }
             });
     } else if (saved) {


### PR DESCRIPTION
## Summary
- load fallback quotes when the API fails
- update weekly quote reset to Monday 5 PM EST

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6843769d401c83228f6a23161de5e867