### PR TITLE
Improve loader visuals and header style

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,6 +94,7 @@ let drops;
 // How often the matrix updates. Higher values slow down the animation.
 const speed = 80; // milliseconds - a bit faster
 let loaderInterval = setInterval(drawLoaderMatrix, speed);
+const minLoadingTime = 2000; // keep loader visible for at least 2s
 // extra pixels to keep frame headers clickable when minimized
 const minimizePadding = 20;
 // Initialize drops based on current window size and update on resize
@@ -583,6 +584,7 @@ function setupSpreadsheet(content) {
 
 function runLoadingSequence() {
     updateProgress(0);
+    const start = Date.now();
     const tasks = [loadWeather(), loadWeeklyQuote(), loadFrames()];
     let done = 0;
     const total = tasks.length;
@@ -592,7 +594,9 @@ function runLoadingSequence() {
             const percent = Math.round((done / total) * 100);
             updateProgress(percent);
             if (done === total) {
-                setTimeout(hideLoader, 300);
+                const elapsed = Date.now() - start;
+                const delay = Math.max(minLoadingTime - elapsed, 0);
+                setTimeout(hideLoader, delay);
             }
         });
     });

--- a/style.css
+++ b/style.css
@@ -63,7 +63,7 @@ body, html {
     background: rgba(0, 16, 0, 0.9);
     color: #fff;
     border: 2px solid #0f0;
-    box-shadow: 0 0 0 2px #0f0 inset;
+    box-shadow: 0 0 10px #0f0, 0 0 0 2px #0f0 inset;
     z-index: 10000; /* ensure the header stays above everything */
 }
 


### PR DESCRIPTION
## Summary
- keep the loading screen visible for at least two seconds
- brighten the header border so all sides match

Manual testing was attempted by starting the server, but it failed because `express` could not be installed.

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68437d1e748c8322b0dd1af214a56901