### PR TITLE
Fix Google Drive image loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -583,13 +583,10 @@ function setupSpreadsheet(content) {
 }
 
 function loadDriveImages(folderId) {
-    const url = `https://drive.google.com/embeddedfolderview?id=${folderId}`;
+    const url = `/drive-images?folderId=${folderId}`;
     return fetch(url)
-        .then(r => r.text())
-        .then(text => {
-            const ids = Array.from(text.matchAll(/data-id="([^"]+)"/g)).map(m => m[1]);
-            return ids.map(id => `https://drive.google.com/uc?export=view&id=${id}`);
-        })
+        .then(r => r.json())
+        .then(data => data.images || [])
         .catch(err => {
             console.error('Failed to load drive images', err);
             return [];

--- a/server.js
+++ b/server.js
@@ -9,6 +9,24 @@ const saveFile = path.join(__dirname, 'frames.json');
 app.use(express.json());
 app.use(express.static(__dirname));
 
+app.get('/drive-images', async (req, res) => {
+  const folderId = req.query.folderId;
+  if (!folderId) {
+    return res.status(400).json({ message: 'Missing folderId' });
+  }
+  try {
+    const url = `https://drive.google.com/embeddedfolderview?id=${folderId}`;
+    const response = await fetch(url);
+    const text = await response.text();
+    const ids = Array.from(text.matchAll(/data-id="([^"]+)"/g)).map(m => m[1]);
+    const images = ids.map(id => `https://drive.google.com/uc?export=view&id=${id}`);
+    res.json({ images });
+  } catch (err) {
+    console.error('Failed to fetch drive images', err);
+    res.json({ images: [] });
+  }
+});
+
 app.get('/frames', (req, res) => {
   fs.readFile(saveFile, 'utf8', (err, data) => {
     if (err) {


### PR DESCRIPTION
## Summary
- add a `/drive-images` endpoint that fetches Google Drive folders server-side
- load Driver Photos images through the new endpoint

Manual testing: Tried `npm start` but it failed because dependencies could not be installed in this environment.

This project has no automated tests.

------
https://chatgpt.com/codex/tasks/task_e_68438015c0448322952a9f90f027e81c