### PR TITLE
Fix duplicate driver photo frame

### DIFF
--- a/script.js
+++ b/script.js
@@ -681,9 +681,11 @@ addButton.addEventListener('click', () => {
     saveFrames();
 });
 
-// start loading sequence and then create carousel frame
+// start loading sequence and create carousel frame only if one isn't loaded
 runLoadingSequence().then(() => {
-    createCarouselFrame('1jEnFkdH4tzxbqAB0TiBkb19TM6z5KVaJ');
+    if (!container.querySelector('.carousel')) {
+        createCarouselFrame('1jEnFkdH4tzxbqAB0TiBkb19TM6z5KVaJ');
+    }
 });
 
 lockButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- stop creating another driver photo frame on each page load

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684381416c1083229c1bbadaabaec510