### PR TITLE
Switch carousel images to local files

### DIFF
--- a/script.js
+++ b/script.js
@@ -582,18 +582,17 @@ function setupSpreadsheet(content) {
     }, true);
 }
 
-function loadDriveImages(folderId) {
-    const url = `/drive-images?folderId=${folderId}`;
-    return fetch(url)
+function loadLocalImages() {
+    return fetch('/images')
         .then(r => r.json())
         .then(data => data.images || [])
         .catch(err => {
-            console.error('Failed to load drive images', err);
+            console.error('Failed to load images', err);
             return [];
         });
 }
 
-function createCarouselFrame(folderId) {
+function createCarouselFrame() {
     const headerHeight = document.getElementById('header').offsetHeight;
     let id;
     if (availableNumbers.length > 0) {
@@ -615,7 +614,7 @@ function createCarouselFrame(folderId) {
     };
     const frame = createFrame(info);
     const inner = frame.querySelector('.carousel-inner');
-    loadDriveImages(folderId).then(urls => {
+    loadLocalImages().then(urls => {
         if (!urls.length) {
             inner.textContent = 'No images found';
             return;
@@ -684,7 +683,7 @@ addButton.addEventListener('click', () => {
 // start loading sequence and create carousel frame only if one isn't loaded
 runLoadingSequence().then(() => {
     if (!container.querySelector('.carousel')) {
-        createCarouselFrame('1jEnFkdH4tzxbqAB0TiBkb19TM6z5KVaJ');
+        createCarouselFrame();
     }
 });
 

--- a/server.js
+++ b/server.js
@@ -9,22 +9,17 @@ const saveFile = path.join(__dirname, 'frames.json');
 app.use(express.json());
 app.use(express.static(__dirname));
 
-app.get('/drive-images', async (req, res) => {
-  const folderId = req.query.folderId;
-  if (!folderId) {
-    return res.status(400).json({ message: 'Missing folderId' });
-  }
-  try {
-    const url = `https://drive.google.com/embeddedfolderview?id=${folderId}`;
-    const response = await fetch(url);
-    const text = await response.text();
-    const ids = Array.from(text.matchAll(/data-id="([^"]+)"/g)).map(m => m[1]);
-    const images = ids.map(id => `https://drive.google.com/uc?export=view&id=${id}`);
+app.get('/images', (req, res) => {
+  fs.readdir(__dirname, (err, files) => {
+    if (err) {
+      console.error('Failed to read images', err);
+      return res.json({ images: [] });
+    }
+    const images = files
+      .filter(f => f.toLowerCase().endsWith('.png'))
+      .map(f => encodeURI(`/${f}`));
     res.json({ images });
-  } catch (err) {
-    console.error('Failed to fetch drive images', err);
-    res.json({ images: [] });
-  }
+  });
 });
 
 app.get('/frames', (req, res) => {


### PR DESCRIPTION
## Summary
- remove Google Drive image fetching on the server
- serve PNG images found in the repo root
- update front-end to consume `/images` endpoint

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684382ffa31c8322b6f1c53752751d56