### PR TITLE
Display PNG carousel

### DIFF
--- a/script.js
+++ b/script.js
@@ -318,7 +318,7 @@ function loadFrames() {
         });
 }
 
-function createFrame(info) {
+function createFrame(info, disableControls = false) {
     const frame = document.createElement('div');
     frame.className = 'frame';
     frame.dataset.id = info.id;
@@ -359,17 +359,19 @@ function createFrame(info) {
         table.appendChild(tbody);
         content.appendChild(table);
     }
-    const controls = document.createElement('div');
-    controls.className = 'table-controls';
-    controls.innerHTML = `
-        <button class="add-row">Add Row</button>
-        <button class="remove-row">Remove Row</button>
-        <button class="add-col">Add Column</button>
-        <button class="remove-col">Remove Column</button>
-    `;
-    content.appendChild(controls);
+    if (!disableControls) {
+        const controls = document.createElement('div');
+        controls.className = 'table-controls';
+        controls.innerHTML = `
+            <button class="add-row">Add Row</button>
+            <button class="remove-row">Remove Row</button>
+            <button class="add-col">Add Column</button>
+            <button class="remove-col">Remove Column</button>
+        `;
+        content.appendChild(controls);
+        setupSpreadsheet(content);
+    }
     frame.appendChild(content);
-    setupSpreadsheet(content);
 
     frame.style.left = (info.left || 0) + 'px';
     frame.style.top = (info.top || 0) + 'px';
@@ -593,7 +595,17 @@ function loadDriveImages(folderId) {
         });
 }
 
-function createCarouselFrame(folderId) {
+function loadLocalImages() {
+    return fetch('/local-images')
+        .then(r => r.json())
+        .then(data => data.images || [])
+        .catch(err => {
+            console.error('Failed to load local images', err);
+            return [];
+        });
+}
+
+function createCarouselFrame() {
     const headerHeight = document.getElementById('header').offsetHeight;
     let id;
     if (availableNumbers.length > 0) {
@@ -613,9 +625,11 @@ function createCarouselFrame(folderId) {
         title: 'Driver Photos',
         content: '<div class="carousel"><div class="carousel-inner"></div></div>'
     };
-    const frame = createFrame(info);
+    const frame = createFrame(info, true);
     const inner = frame.querySelector('.carousel-inner');
-    loadDriveImages(folderId).then(urls => {
+    const leftover = frame.querySelector('.table-controls');
+    if (leftover) leftover.remove();
+    loadLocalImages().then(urls => {
         if (!urls.length) {
             inner.textContent = 'No images found';
             return;
@@ -684,7 +698,7 @@ addButton.addEventListener('click', () => {
 // start loading sequence and create carousel frame only if one isn't loaded
 runLoadingSequence().then(() => {
     if (!container.querySelector('.carousel')) {
-        createCarouselFrame('1jEnFkdH4tzxbqAB0TiBkb19TM6z5KVaJ');
+        createCarouselFrame();
     }
 });
 

--- a/server.js
+++ b/server.js
@@ -9,6 +9,19 @@ const saveFile = path.join(__dirname, 'frames.json');
 app.use(express.json());
 app.use(express.static(__dirname));
 
+app.get('/local-images', (req, res) => {
+  fs.readdir(__dirname, (err, files) => {
+    if (err) {
+      console.error('Failed to read directory', err);
+      return res.json({ images: [] });
+    }
+    const images = files
+      .filter(f => /\.png$/i.test(f))
+      .map(f => '/' + f);
+    res.json({ images });
+  });
+});
+
 app.get('/drive-images', async (req, res) => {
   const folderId = req.query.folderId;
   if (!folderId) {


### PR DESCRIPTION
## Summary
- disable leftover controls when building the photo carousel
- serve `.png` filenames without encoding

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6843a83587a883229c5db055333232a9