### PR TITLE
Fix local PNG carousel loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -359,15 +359,7 @@ function createFrame(info, disableControls = false) {
         table.appendChild(tbody);
         content.appendChild(table);
     }
-// ————— driver-photo frame cleanup —————
-const leftover = frame.querySelector('.table-controls');
-if (leftover) leftover.remove();
-
-// … other code …
-
-// make every file path safe for URLs
-.map(f => '/' + encodeURIComponent(f));
-
+    if (!disableControls) {
         const controls = document.createElement('div');
         controls.className = 'table-controls';
         controls.innerHTML = `
@@ -592,6 +584,17 @@ function setupSpreadsheet(content) {
     }, true);
 }
 
+function loadDriveImages(folderId) {
+    const url = `/drive-images?folderId=${folderId}`;
+    return fetch(url)
+        .then(r => r.json())
+        .then(data => data.images || [])
+        .catch(err => {
+            console.error('Failed to load drive images', err);
+            return [];
+        });
+}
+
 function loadLocalImages() {
     return fetch('/local-images')
         .then(r => r.json())
@@ -601,15 +604,6 @@ function loadLocalImages() {
             return [];
         });
 }
-
-// ————— driver-photo frame cleanup —————
-const leftover = frame.querySelector('.table-controls');
-if (leftover) leftover.remove();
-
-// … other code …
-
-// make every file path safe for URLs
-.map(f => '/' + encodeURIComponent(f));
 
 function createCarouselFrame() {
     const headerHeight = document.getElementById('header').offsetHeight;

--- a/server.js
+++ b/server.js
@@ -16,15 +16,10 @@ const mimeTypes = {
   '.txt': 'text/plain'
 };
 
-// ————— driver-photo frame cleanup —————
-const leftover = frame.querySelector('.table-controls');
-if (leftover) leftover.remove();
-
-// … other code …
-
-// make every file path safe for URLs
-.map(f => '/' + encodeURIComponent(f));
-
+function sendJson(res, obj, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
 
 function serveStatic(res, filePath) {
   fs.readFile(filePath, (err, data) => {


### PR DESCRIPTION
## Summary
- remove merge leftovers from `server.js` and `script.js`
- restore ability to list `.png` files from the project directory
- show those images in the Driver Photos frame carousel

Manual testing: started the server with `npm start` and confirmed it runs without errors.

Project has no tests.

------
https://chatgpt.com/codex/tasks/task_e_6843b03ec7188322b14d320172c2bdfd